### PR TITLE
Add docker-compose file with MongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+  mongo:
+    image: mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example


### PR DESCRIPTION
Adds a docker-compose file with MongoDB. We can add our own container here as well, once we build the Docker file. Our container can communicate with Mongo over the internal Docker network.